### PR TITLE
Apply custom date range limit for specific stream

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-mixpanel',
-      version='1.2.0',
+      version='1.2.1-airbyte',
       description='Singer.io tap for extracting data from the mixpanel API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_mixpanel/sync.py
+++ b/tap_mixpanel/sync.py
@@ -473,12 +473,13 @@ def apply_date_range_limit(stream_name: str, start_date: str, date_range: int) -
     custom_start_date = strptime_to_utc(start_date)
     now_dttm = utils.now()
     delta_days = (now_dttm - custom_start_date).days
-    if delta_days >= date_range:
+    if delta_days > date_range:
         delta_days = date_range
         custom_start_date = strftime(now_dttm - timedelta(days=delta_days))
         LOGGER.warning(f"WARNING: start_date greater than {date_range} days maximum for {stream_name} stream.")
         LOGGER.warning(f"WARNING: Setting start_date to {date_range} days ago, {start_date}")
-    return custom_start_date
+        return custom_start_date
+    return start_date
 
 
 def sync(client, config, catalog, state, start_date):


### PR DESCRIPTION
# Description of change
Some streams has specific date range limit. E.g, Annotation has 90 days limit.
